### PR TITLE
feat(statusline): use git diff stats instead of Claude session stats

### DIFF
--- a/internal/application/statusline.go
+++ b/internal/application/statusline.go
@@ -71,7 +71,7 @@ func (s *StatusLineService) Generate(input *model.Input) string {
 		Terminal:    s.terminalProv.Info(),
 		Dir:         input.WorkingDir(),
 		Time:        time.Now().Format(timeFormat),
-		Changes:     input.CodeChanges(),
+		Changes:     s.gitRepo.DiffStats(),
 		MCP:         s.mcpProv.Servers(),
 		Taskwarrior: s.taskwarriorProv.Info(),
 	}

--- a/internal/domain/port/git.go
+++ b/internal/domain/port/git.go
@@ -11,4 +11,10 @@ type GitRepository interface {
 	// Returns:
 	//   - model.GitStatus: branch and change information
 	Status() model.GitStatus
+
+	// DiffStats returns lines added and removed from git diff.
+	//
+	// Returns:
+	//   - model.CodeChanges: lines added and removed
+	DiffStats() model.CodeChanges
 }


### PR DESCRIPTION
## Summary

Replace Claude's session line counts with actual git diff stats.
Shows real uncommitted changes (+added/-removed lines).

## Before
`+453 -141` (Claude session cumulative stats)

## After
`+74 -1` (actual git diff HEAD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)