### PR TITLE
feat(statusline): integrate model segment into line 1

### DIFF
--- a/internal/presentation/renderer/colors.go
+++ b/internal/presentation/renderer/colors.go
@@ -1,11 +1,7 @@
 // Package renderer provides status line rendering.
 package renderer
 
-import (
-	"strings"
-
-	"github.com/florent/status-line/internal/domain/model"
-)
+import "strings"
 
 // ANSI escape codes for terminal formatting.
 const (
@@ -77,18 +73,6 @@ const (
 	FgOpusDark string = "\033[38;5;172m"
 )
 
-// Progress bar color constants (darker for white background).
-const (
-	// ColorGreen is the dark green foreground for low usage.
-	ColorGreen string = "\033[38;5;28m"
-	// ColorYellow is the dark yellow/olive foreground for medium usage.
-	ColorYellow string = "\033[38;5;136m"
-	// ColorOrange is the dark orange foreground for high usage.
-	ColorOrange string = "\033[38;5;166m"
-	// ColorRed is the dark red foreground for critical usage.
-	ColorRed string = "\033[38;5;124m"
-)
-
 // Code changes segment colors (pale backgrounds, darker text).
 const (
 	// BgGreen is the pale green background for lines added.
@@ -136,35 +120,6 @@ const (
 	// ColorGray is the gray foreground for incomplete progress.
 	ColorGray string = "\033[38;5;245m"
 )
-
-// GetProgressColor returns color for a progress level.
-//
-// Params:
-//   - level: the progress severity level
-//
-// Returns:
-//   - string: ANSI color code for the level
-func GetProgressColor(level model.ProgressLevel) string {
-	// Select color based on level
-	switch level {
-	// Green for low/safe usage
-	case model.LevelLow:
-		// Return green color
-		return ColorGreen
-	// Yellow for medium usage
-	case model.LevelMedium:
-		// Return yellow color
-		return ColorYellow
-	// Orange for high usage
-	case model.LevelHigh:
-		// Return orange color
-		return ColorOrange
-	// Red for critical usage
-	default:
-		// Return red color
-		return ColorRed
-	}
-}
 
 // GetModelColors returns colors for a model pill.
 //

--- a/internal/presentation/renderer/progressbar.go
+++ b/internal/presentation/renderer/progressbar.go
@@ -117,18 +117,3 @@ func RenderProgressBar(progress model.Progress, style ProgressBarStyle) string {
 	// Return completed progress bar
 	return string(result)
 }
-
-// RenderProgressBarWithColor generates a colored progress bar.
-//
-// Params:
-//   - progress: the progress value (0-100%)
-//   - style: the visual style to use
-//
-// Returns:
-//   - string: rendered progress bar with ANSI color codes
-func RenderProgressBarWithColor(progress model.Progress, style ProgressBarStyle) string {
-	bar := RenderProgressBar(progress, style)
-	color := GetProgressColor(progress.Level())
-	// Return bar with color applied
-	return color + bar + Reset
-}


### PR DESCRIPTION
## Summary
- Move AI model from pill (line 2) to integrated segment (line 1)
- New segment order: OS → Model → Path → Git → Changes
- Use model's text color for progress bar (unified look)
- Remove progress level colors (green/yellow/orange/red)
- Keep pills for dynamic elements only (Taskwarrior, MCP)

## Test plan
- [x] Build passes (`make build`)
- [x] Tested with Opus, Sonnet, Haiku models
- [x] Verified color transitions between segments

🤖 Generated with [Claude Code](https://claude.com/claude-code)