### PR TITLE
feat: add Windows builds (amd64/arm64)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,10 @@ jobs:
             goarch: amd64
           - goos: darwin
             goarch: arm64
+          - goos: windows
+            goarch: amd64
+          - goos: windows
+            goarch: arm64
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,10 @@ jobs:
             goarch: amd64
           - goos: darwin
             goarch: arm64
+          - goos: windows
+            goarch: amd64
+          - goos: windows
+            goarch: arm64
 
     steps:
       - name: Checkout repository
@@ -68,6 +72,10 @@ jobs:
         run: |
           mkdir -p dist
           BINARY="${BINARY_NAME}-${{ matrix.goos }}-${{ matrix.goarch }}"
+          # Add .exe extension for Windows
+          if [ "${{ matrix.goos }}" = "windows" ]; then
+            BINARY="${BINARY}.exe"
+          fi
           go build -ldflags="-s -w -X main.version=${{ steps.version.outputs.version }}" \
             -o "dist/${BINARY}" \
             ./cmd/statusline


### PR DESCRIPTION
## Summary
Add Windows support for the build pipeline.

## Changes
- Add `windows/amd64` and `windows/arm64` to CI build matrix
- Add `windows/amd64` and `windows/arm64` to Release build matrix
- Add `.exe` extension for Windows binaries

## Test plan
- [x] CI builds should pass for all 6 platforms (linux, darwin, windows × amd64, arm64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)