### PR TITLE
fix(ui): change burn-rate cursor color from orange to black

### DIFF
--- a/internal/presentation/renderer/powerline.go
+++ b/internal/presentation/renderer/powerline.go
@@ -159,7 +159,7 @@ func (r *Powerline) renderModelSegment(sb *strings.Builder, data *ModelSegmentDa
 	// Check if we have valid cursor data
 	if data.Cursor != nil && data.Cursor.IsValid() {
 		// Render with burn-rate cursor
-		bar = RenderProgressBarWithCursor(data.Progress, data.Cursor.CursorPosition(), FgCursorOrange, bgColor+textColor+Bold)
+		bar = RenderProgressBarWithCursor(data.Progress, data.Cursor.CursorPosition(), FgBlack, bgColor+textColor+Bold)
 	} else {
 		// Render without cursor (no API data available)
 		bar = RenderProgressBar(data.Progress, StyleHeavy)


### PR DESCRIPTION
## Summary
- Changes the burn-rate cursor in the progress bar from orange (`FgCursorOrange`) to black (`FgBlack`)
- Provides cleaner visual appearance on model pills

## Test plan
- [x] Linter passes
- [x] Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)