### PR TITLE
fix(mcp): read config from correct Claude Code locations

### DIFF
--- a/internal/adapter/mcp/settings.go
+++ b/internal/adapter/mcp/settings.go
@@ -1,8 +1,20 @@
 // Package mcp provides the MCP configuration adapter.
 package mcp
 
-// settingsFile represents the Claude settings.json structure.
-// It contains MCP server configurations.
-type settingsFile struct {
+// claudeConfigFile represents the ~/.claude/.claude.json structure.
+// It contains project-specific MCP server configurations.
+type claudeConfigFile struct {
+	Projects map[string]projectConfig `json:"projects"`
+}
+
+// projectConfig represents a project's configuration in .claude.json.
+// It contains MCP server configurations for a specific project.
+type projectConfig struct {
+	MCPServers map[string]mcpServerConfig `json:"mcpServers"`
+}
+
+// mcpJsonFile represents the {project}/.mcp.json structure.
+// It contains MCP server configurations at project level.
+type mcpJsonFile struct {
 	MCPServers map[string]mcpServerConfig `json:"mcpServers"`
 }


### PR DESCRIPTION
## Summary
- Read MCP server config from correct Claude Code locations:
  - `~/.claude/.claude.json` → `projects["/path"].mcpServers`
  - `{project}/.mcp.json` → `mcpServers`
- Previously read from wrong paths (`settings.json`), causing MCP servers to not appear in status line
- This fixes taskwarrior MCP and other servers not being displayed

## Test plan
- [x] Build passes (`make build`)
- [x] Tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [ ] Manual test: verify MCP servers appear in status line when configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)