### PR TITLE
fix(ci): trigger release workflow after auto-tagging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,3 +183,11 @@ jobs:
           git tag -a "${{ steps.version.outputs.version }}" -m "Release ${{ steps.version.outputs.version }}"
           git push origin "${{ steps.version.outputs.version }}"
           echo "✅ Created and pushed tag ${{ steps.version.outputs.version }}"
+
+      - name: Trigger release workflow
+        if: steps.check_tag.outputs.exists == 'false'
+        run: |
+          gh workflow run release.yml --field tag=${{ steps.version.outputs.version }}
+          echo "✅ Triggered release workflow for ${{ steps.version.outputs.version }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Fix automatic releases not being created after merge to main
- GitHub's `GITHUB_TOKEN` does not trigger other workflows when pushing tags (anti-loop protection)
- Added explicit `workflow_dispatch` call to trigger the release workflow after creating a new tag

## Root cause
The `auto-release` job creates and pushes tags using `GITHUB_TOKEN`, but this doesn't trigger the `release.yml` workflow due to GitHub's security measures.

## Test plan
- [x] Manually triggered release for v0.4.1 to verify workflow works
- [ ] Next merge to main should automatically create release

🤖 Generated with [Claude Code](https://claude.com/claude-code)