### PR TITLE
fix(ci): use PAT to push tags and trigger release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,13 +181,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "${{ steps.version.outputs.version }}" -m "Release ${{ steps.version.outputs.version }}"
-          git push origin "${{ steps.version.outputs.version }}"
+          git push https://x-access-token:${{ secrets.PAT }}@github.com/${{ github.repository }}.git "${{ steps.version.outputs.version }}"
           echo "✅ Created and pushed tag ${{ steps.version.outputs.version }}"
-
-      - name: Trigger release workflow
-        if: steps.check_tag.outputs.exists == 'false'
-        run: |
-          gh workflow run release.yml --field tag=${{ steps.version.outputs.version }}
-          echo "✅ Triggered release workflow for ${{ steps.version.outputs.version }}"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Remove useless `gh workflow run` (GITHUB_TOKEN can't trigger workflows)
- Use PAT to push tags instead of GITHUB_TOKEN
- When a tag is pushed with a PAT, it properly triggers the release workflow

## Required action
Add a **Personal Access Token** as a repository secret:
1. Go to GitHub → Settings → Developer settings → Personal access tokens
2. Create a token with `repo` scope
3. Add it as a secret named `PAT` in repository settings

## How it works
```
push to main → CI runs → auto-release job → push tag with PAT → release workflow triggers
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)