### PR TITLE
ci(release): trigger devcontainer rebuild on new release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,9 @@ jobs:
     needs: [test, build]
     permissions:
       contents: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      released: ${{ steps.check_release.outputs.exists == 'false' }}
 
     steps:
       - name: Checkout repository
@@ -213,3 +216,21 @@ jobs:
           prerelease: false
           generate_release_notes: true
           files: dist/*
+
+  # =============================================================================
+  # Trigger devcontainer-template rebuild
+  # =============================================================================
+  trigger-devcontainer:
+    name: Trigger devcontainer rebuild
+    needs: auto-release
+    runs-on: ubuntu-latest
+    if: needs.auto-release.outputs.released == 'true'
+
+    steps:
+      - name: Trigger devcontainer-template build
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
+        with:
+          token: ${{ secrets.DEVCONTAINER_TRIGGER_PAT }}
+          repository: kodflow/devcontainer-template
+          event-type: status-line-release
+          client-payload: '{"version": "${{ needs.auto-release.outputs.version }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
### **User description**
## Summary
- Add `trigger-devcontainer` job to CI workflow that sends a `repository_dispatch` event (`status-line-release`) to `kodflow/devcontainer-template` when a new release is created
- Mirrors the existing pattern from `ktn-linter` using `peter-evans/repository-dispatch@v4.0.1`
- Only triggers for actual new releases (skipped when release already exists)

## Prerequisites
- [ ] Add `DEVCONTAINER_TRIGGER_PAT` secret to this repo (or verify org-level secret)
- [ ] Add `status-line-release` to `repository_dispatch.types` in `devcontainer-template`'s `docker-images.yml`

## Test plan
- [ ] Verify workflow YAML is valid (CI will validate on push)
- [ ] After merging: confirm `trigger-devcontainer` job appears in Actions
- [ ] On next release: verify dispatch event triggers devcontainer-template rebuild


___

### **PR Type**
Enhancement


___

### **Description**
- Add `trigger-devcontainer` job to CI workflow for automated rebuilds

- Send `repository_dispatch` event to `kodflow/devcontainer-template` on release

- Export version and release status from `auto-release` job as outputs

- Only trigger devcontainer rebuild when new release is created


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["auto-release job"] -->|"outputs: version, released"| B["trigger-devcontainer job"]
  B -->|"repository_dispatch event"| C["devcontainer-template rebuild"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Add devcontainer rebuild trigger job to CI workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Added <code>outputs</code> section to <code>auto-release</code> job exposing <code>version</code> and <br><code>released</code> status<br> <li> Created new <code>trigger-devcontainer</code> job that depends on <code>auto-release</code> <br>completion<br> <li> Configured job to send <code>repository_dispatch</code> event with event-type <br><code>status-line-release</code> to <code>kodflow/devcontainer-template</code><br> <li> Job only executes when <code>released</code> output is <code>true</code>, preventing duplicate <br>triggers</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/status-line/pull/27/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+21/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

